### PR TITLE
Improve parsing of MIME parameter part

### DIFF
--- a/flanker/mime/message/headers/parametrized.py
+++ b/flanker/mime/message/headers/parametrized.py
@@ -107,8 +107,10 @@ def concatenate(parts):
     if is_old_style(part):
         # old-style parameters do not support any continuations
         return encodedword.mime_to_unicode(get_value(part))
-
-    return ''.join(decode_new_style(p) for p in partition(parts))
+    elif is_single_part(part):
+        return decode_new_style(part)
+    else:
+        return ''.join(decode_new_style(p) for p in partition(parts))
 
 
 def match_parameter(rest):
@@ -232,6 +234,10 @@ def is_old_style(parameter):
 
 def is_encoded(part):
     return part[1][2] == '*'
+
+
+def is_single_part(part):
+    return part[1][1] is None
 
 
 def get_key(parameter):

--- a/flanker/mime/message/headers/parametrized.py
+++ b/flanker/mime/message/headers/parametrized.py
@@ -110,7 +110,8 @@ def concatenate(parts):
     elif is_single_part(part):
         return decode_new_style(part)
     else:
-        return ''.join(decode_new_style(p) for p in partition(parts))
+        splitted_parts = (part for part in parts if not is_single_part(part))
+        return ''.join(decode_new_style(p) for p in partition(splitted_parts))
 
 
 def match_parameter(rest):

--- a/tests/mime/message/headers/parametrized_test.py
+++ b/tests/mime/message/headers/parametrized_test.py
@@ -64,5 +64,10 @@ def content_types_test():
     eq_(('multipart/mixed', {'boundary': 'Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2=Yt1KaFdA'}), parametrized.decode(''' multipart/mixed; \n\tboundary="Alternative_Boundary_8dJn:mu0M2Yt5KaFZ8AdJn:mu0M2=Yt1KaFdA"'''))
     eq_(('multipart/mixed', {'boundary': '16819560-2078917053-688350843:#11603'}), parametrized.decode('''MULTIPART/MIXED;BOUNDARY="16819560-2078917053-688350843:#11603"'''))
 
+
 def content_type_param_with_spaces_test():
-    eq_(('multipart/alternative',{'boundary':'nextPart'}), parametrized.decode("multipart/alternative; boundary = nextPart"))
+    eq_(('multipart/alternative', {'boundary': 'nextPart'}), parametrized.decode("multipart/alternative; boundary = nextPart"))
+
+
+def content_type_same_param_name_encoded_unencoded_test():
+    eq_(('application/pdf', {'name': '30676_2015.pdf'}), parametrized.decode("application/pdf; name=30676_2015.pdf;name*=iso-8859-1''%33%30%36%37%36%5F%32%30%31%35%2E%70%64%66"))

--- a/tests/mime/message/headers/parametrized_test.py
+++ b/tests/mime/message/headers/parametrized_test.py
@@ -71,3 +71,4 @@ def content_type_param_with_spaces_test():
 
 def content_type_same_param_name_encoded_unencoded_test():
     eq_(('application/pdf', {'name': '30676_2015.pdf'}), parametrized.decode("application/pdf; name=30676_2015.pdf;name*=iso-8859-1''%33%30%36%37%36%5F%32%30%31%35%2E%70%64%66"))
+    eq_(('application/pdf', {'name': '30676_2015.pdf'}), parametrized.decode("application/pdf; name*0*=iso-8859-1''%33%30%36%37%36%5F%32%30%31%35%2E%70%64%66;name=30676_2015.pdf"))


### PR DESCRIPTION
Like https://github.com/mailgun/flanker/pull/103, but also prevents concatenating splitted and unsplitted params.